### PR TITLE
Fix standalone stability on macOS and showcase startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Windows is fully verified. macOS builds but has not been extensively tested in D
 |---------|-----|
 | `WAMR runtime library not found` | Re-run the setup script |
 | `wamrc not found` | Re-run the setup script |
+| Standalone app hangs on exit (macOS rainbow spinner / high CPU) | Rebuild WAMR with `-DWAMR_DISABLE_HW_BOUND_CHECK=1`, then rebuild plugin |
 | UI shows `JUCE bridge not available` | Start Vite dev server (`npm run dev`) or run `npm run build:ui` before `npm run build:plugin` |
 | JUCE/WAMR build issues | Run `git submodule update --init --recursive` |
 

--- a/plugin/include/moonvst/WasmDSP.h
+++ b/plugin/include/moonvst/WasmDSP.h
@@ -48,9 +48,9 @@ private:
     static constexpr int INPUT_RIGHT_OFFSET = 0x20000;
     static constexpr int OUTPUT_LEFT_OFFSET = 0x30000;
     static constexpr int OUTPUT_RIGHT_OFFSET = 0x40000;
+    static constexpr int MAX_BUFFER_SAMPLES = 16384;
 
     std::atomic<bool> initialized_ { false };
-    std::atomic<bool> runtimeInitialized_ { false };
     int cachedParamCount_ = 0;
 
     bool lookupFunctions();

--- a/plugin/src/PluginEditor.cpp
+++ b/plugin/src/PluginEditor.cpp
@@ -82,7 +82,14 @@ PluginEditor::PluginEditor (PluginProcessor& p)
 #endif
 }
 
-PluginEditor::~PluginEditor() = default;
+PluginEditor::~PluginEditor()
+{
+    // Destroy WebView first while relay/listener objects are still alive.
+    // This avoids dangling WebViewLifetimeListener pointers during teardown.
+    webView.reset();
+    sliderAttachments.clear();
+    sliderRelays.clear();
+}
 
 bool PluginEditor::setupWebView()
 {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -58,7 +58,8 @@ cmake .. \
     -DWAMR_BUILD_AOT=1 \
     -DWAMR_BUILD_INTERP=0 \
     -DWAMR_BUILD_LIBC_BUILTIN=1 \
-    -DWAMR_BUILD_LIBC_WASI=0
+    -DWAMR_BUILD_LIBC_WASI=0 \
+    -DWAMR_DISABLE_HW_BOUND_CHECK=1
 make -j$(sysctl -n hw.ncpu)
 
 # 4. Install LLVM (required for wamrc AOT compiler)

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -36,7 +36,8 @@ cmake .. `
     -DWAMR_BUILD_AOT=1 `
     -DWAMR_BUILD_INTERP=0 `
     -DWAMR_BUILD_LIBC_BUILTIN=1 `
-    -DWAMR_BUILD_LIBC_WASI=0
+    -DWAMR_BUILD_LIBC_WASI=0 `
+    -DWAMR_DISABLE_HW_BOUND_CHECK=1
 cmake --build . --config Release
 
 # 3. Download LLVM libraries (required for wamrc AOT compiler)

--- a/tests/cpp/wasm_dsp_test.cpp
+++ b/tests/cpp/wasm_dsp_test.cpp
@@ -76,7 +76,7 @@ int main()
     printf("PASS: Module loaded\n");
 
     // 4. Instantiate
-    wasm_module_inst_t inst = wasm_runtime_instantiate(module, 256 * 1024, 1024 * 1024,
+    wasm_module_inst_t inst = wasm_runtime_instantiate(module, 512 * 1024, 64 * 1024 * 1024,
                                                         errorBuf, sizeof(errorBuf));
     if (!inst)
     {


### PR DESCRIPTION
## Summary
- stabilize macOS standalone behavior around WebView backend handling
- fix showcase startup crash path
- include related setup script and C++ test updates\n\n## Changed files
- README.md
- plugin/include/moonvst/WasmDSP.h
- plugin/src/PluginEditor.cpp
- plugin/src/WasmDSP.cpp
- scripts/setup-macos.sh
- scripts/setup-windows.ps1
-  tests/cpp/wasm_dsp_test.cpp\n\n## Validation
- local verification performed during development