### PR TITLE
fix(ci): move macOS pipeline to macos-26 and add exit stress diagnostics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           echo "Discovered products: $products_json"
 
   build-macos:
-    runs-on: macos-14
+    runs-on: macos-26
     needs: discover-products
     env:
       MACOS_CERT_P12_B64: ${{ secrets.MACOS_CERT_P12_B64 }}
@@ -41,6 +41,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Log macOS toolchain info
+        shell: bash
+        run: |
+          set -euo pipefail
+          sw_vers
+          uname -a
+          xcodebuild -version
+          clang --version | head -n 1
 
       - name: Run macOS setup script
         run: bash scripts/setup-macos.sh
@@ -70,6 +79,11 @@ jobs:
           for product in $(node -e "const p=JSON.parse(process.argv[1]);console.log(p.join(' '));" "$products"); do
             echo "=== Building product: $product ==="
             target_suffix="${product//-/_}"
+            product_dir="ci-artifacts/$product"
+            diagnostics_dir="$product_dir/diagnostics"
+            mkdir -p "$product_dir/plugin" "$product_dir/tests" "$diagnostics_dir"
+            exec > >(tee -a "$diagnostics_dir/build.log")
+            exec 2>&1
 
             if [ "$product" = "template" ]; then
               npm run build:dsp
@@ -82,6 +96,17 @@ jobs:
             cmake -B build -DCMAKE_BUILD_TYPE=Release -DMOONVST_ENABLE_UNITY=ON -DBUILD_TESTS=ON -DMOONVST_PRODUCT="$product"
             npm run build:plugin
             artefacts_root="build/plugin/MoonVST_${target_suffix}_artefacts/Release"
+            plugin_binary="$artefacts_root/VST3/${product}.vst3/Contents/MacOS/${product}"
+
+            {
+              echo "=== System info ==="
+              sw_vers
+              uname -a
+              xcodebuild -version
+              echo "=== Plugin LC_BUILD_VERSION ==="
+              otool -l "$plugin_binary" | grep -A5 LC_BUILD_VERSION
+            } > "$diagnostics_dir/plugin_metadata.log"
+            grep -E "target:[[:space:]]|target triple:" "$diagnostics_dir/build.log" > "$diagnostics_dir/wamrc_target.log" || true
 
             if [ -n "${MACOS_SIGN_IDENTITY:-}" ]; then
               for bundle in \
@@ -95,8 +120,6 @@ jobs:
               done
             fi
 
-            product_dir="ci-artifacts/$product"
-            mkdir -p "$product_dir/plugin" "$product_dir/tests"
             cp -R "$artefacts_root/VST3" "$product_dir/plugin/VST3"
             cp -R "$artefacts_root/Standalone" "$product_dir/plugin/Standalone"
             cp -R "$artefacts_root/Unity" "$product_dir/plugin/Unity"
@@ -192,7 +215,7 @@ jobs:
           path: ci-artifacts/
 
   test-artifact-macos:
-    runs-on: macos-14
+    runs-on: macos-26
     needs: [discover-products, build-macos]
     steps:
       - name: Download product artifacts
@@ -249,7 +272,7 @@ jobs:
           }
 
   release:
-    runs-on: macos-14
+    runs-on: macos-26
     needs: [discover-products, test-artifact-macos, test-artifact-windows]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Windows is fully verified. macOS builds but has not been extensively tested in D
 | `WAMR runtime library not found` | Re-run the setup script |
 | `wamrc not found` | Re-run the setup script |
 | Standalone app hangs on exit (macOS rainbow spinner / high CPU) | Rebuild WAMR with `-DWAMR_DISABLE_HW_BOUND_CHECK=1`, then rebuild plugin |
+| CI-built macOS plugin crashes in DAW but local build is stable | Align CI runner OS/toolchain with target macOS generation (use `macos-26` for macOS 26 hosts), rebuild artifact, and compare `LC_BUILD_VERSION` + wamrc target logs |
 | UI shows `JUCE bridge not available` | Start Vite dev server (`npm run dev`) or run `npm run build:ui` before `npm run build:plugin` |
 | JUCE/WAMR build issues | Run `git submodule update --init --recursive` |
 | Downloaded macOS plugin/app is blocked (`damaged`, `cannot be opened`) during local development | Remove `com.apple.quarantine` from installed bundle paths (commands below). For distribution, use proper code signing and notarization. |

--- a/tests/cpp/plugin_smoke_test.cpp
+++ b/tests/cpp/plugin_smoke_test.cpp
@@ -11,6 +11,7 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter();
 int main()
 {
     printf("=== Plugin Smoke Test ===\n");
+    constexpr int kEditorOpenCloseIterations = 200;
 
     juce::ScopedJuceInitialiser_GUI juceInit;
 
@@ -39,27 +40,31 @@ int main()
     }
     printf("PASS: processBlock executed\n");
 
-    auto* editor = plugin->createEditor();
-    if (editor == nullptr)
+    for (int i = 0; i < kEditorOpenCloseIterations; ++i)
     {
-        printf("FAIL: createEditor returned null\n");
-        return 1;
-    }
+        auto* editor = plugin->createEditor();
+        if (editor == nullptr)
+        {
+            printf("FAIL: createEditor returned null at iteration %d\n", i + 1);
+            return 1;
+        }
 
-    const auto editorBounds = editor->getBounds();
-    if (editorBounds.getWidth() <= 0 || editorBounds.getHeight() <= 0)
-    {
-        printf("FAIL: editor has invalid bounds (%d, %d)\n",
-               editorBounds.getWidth(),
-               editorBounds.getHeight());
+        const auto editorBounds = editor->getBounds();
+        if (editorBounds.getWidth() <= 0 || editorBounds.getHeight() <= 0)
+        {
+            printf("FAIL: editor has invalid bounds at iteration %d (%d, %d)\n",
+                   i + 1,
+                   editorBounds.getWidth(),
+                   editorBounds.getHeight());
+            delete editor;
+            return 1;
+        }
+
         delete editor;
-        return 1;
     }
-    printf("PASS: Editor created (%d x %d)\n",
-           editorBounds.getWidth(),
-           editorBounds.getHeight());
+    printf("PASS: Editor open/close stress (%d iterations)\n",
+           kEditorOpenCloseIterations);
 
-    delete editor;
     plugin->releaseResources();
 
     auto* typed = dynamic_cast<PluginProcessor*>(plugin.get());


### PR DESCRIPTION
## Summary\n- move macOS CI jobs from  to \n- add macOS build diagnostics (ProductName:		macOS
ProductVersion:		26.2
BuildVersion:		25C56, Darwin JPCD2X2YH4QXM 25.2.0 Darwin Kernel Version 25.2.0: Tue Nov 18 21:08:48 PST 2025; root:xnu-12377.61.12~1/RELEASE_ARM64_T8132 arm64, , Apple clang version 17.0.0 (clang-1700.6.3.2)
Target: arm64-apple-darwin25.2.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin)\n- persist plugin  and extracted wamrc target/triple logs in artifacts\n- add editor open/close stress loop (200 iterations) in plugin smoke test\n- document macOS runner/toolchain alignment guidance in troubleshooting\n\n## Validation\n- CI run required (workflow changes)\n- local smoke target build not run in this worktree because  was not present