### PR TITLE
fix: pass sample rate to WASM DSP module

### DIFF
--- a/packages/dsp-core/src/effects/chorus.mbt
+++ b/packages/dsp-core/src/effects/chorus.mbt
@@ -1,4 +1,3 @@
-let chorus_sample_rate_hz : Float = 48000.0
 let chorus_total_samples : Int = 16386
 let chorus_loop_limit : Int = 8176
 let chorus_loop_limit_f : Float = 8176.0
@@ -114,7 +113,7 @@ fn chorus_sin(x : Float) -> Float {
 }
 
 fn chorus_speed_from_rate(rate : Float) -> Float {
-  let overallscale = chorus_sample_rate_hz / 44100.0
+  let overallscale = @utils.get_sample_rate() / 44100.0
   let a2 = rate * rate
   let a4 = a2 * a2
   a4 * 0.001 * overallscale

--- a/packages/dsp-core/src/effects/compressor.mbt
+++ b/packages/dsp-core/src/effects/compressor.mbt
@@ -2,7 +2,6 @@ let compressor_max_nodes : Int = 16
 let compressor_max_delay : Int = 1024
 let compressor_samples_per_update : Int = 32
 let compressor_spacing_db : Float = 5.0
-let compressor_sample_rate_hz : Float = 48000.0
 let compressor_ang_90 : Float = 1.57079633
 let compressor_ang_90_inv : Float = 0.63661977236
 let compressor_release_zone1 : Float = 0.090
@@ -131,11 +130,12 @@ fn compressor_delay_offset(node_index : Int, sample_index : Int) -> Int {
 
 fn ensure_compressor_state() -> Unit {
   for i = compressor_linearpregain.length(); i < compressor_max_nodes; i = i + 1 {
+    let sample_rate_hz = @utils.get_sample_rate()
     compressor_linearpregain.push(1.0)
     compressor_linearthreshold.push(compressor_db2lin(-24.0))
     compressor_slope.push(1.0 / 12.0)
-    compressor_attacksamplesinv.push(1.0 / (compressor_sample_rate_hz * 0.003))
-    compressor_satreleasesamplesinv.push(1.0 / (compressor_sample_rate_hz * 0.0025))
+    compressor_attacksamplesinv.push(1.0 / (sample_rate_hz * 0.003))
+    compressor_satreleasesamplesinv.push(1.0 / (sample_rate_hz * 0.0025))
     compressor_wet.push(1.0)
     compressor_dry.push(0.0)
     compressor_k.push(5.0)
@@ -201,13 +201,14 @@ fn compressor_reconfigure(
   wet : Float,
   reset_runtime : Bool,
 ) -> Unit {
+  let sample_rate_hz = @utils.get_sample_rate()
   let clamped_ratio : Float = if ratio < 1.0 { 1.0 } else { ratio }
   let clamped_attack_sec : Float = effect_clamp(attack_sec, 0.000001, 1.0)
   let clamped_release_sec : Float = effect_clamp(release_sec, 0.000001, 1.0)
   let clamped_predelay_sec : Float = effect_clamp(predelay_sec, 0.0, 1.0)
   let clamped_knee_db : Float = effect_clamp(knee_db, 0.0, 40.0)
   let clamped_wet : Float = effect_clamp(wet, 0.0, 1.0)
-  let mut delaybufsize = (compressor_sample_rate_hz * clamped_predelay_sec).to_int()
+  let mut delaybufsize = (sample_rate_hz * clamped_predelay_sec).to_int()
   if delaybufsize < 1 {
     delaybufsize = 1
   } else if delaybufsize > compressor_max_delay {
@@ -231,12 +232,12 @@ fn compressor_reconfigure(
   let linearpregain : Float = compressor_db2lin(pregain_db)
   let linearthreshold : Float = compressor_db2lin(threshold_db)
   let slope : Float = 1.0 / clamped_ratio
-  let attacksamples : Float = compressor_sample_rate_hz * clamped_attack_sec
-  let releasesamples : Float = compressor_sample_rate_hz * clamped_release_sec
+  let attacksamples : Float = sample_rate_hz * clamped_attack_sec
+  let releasesamples : Float = sample_rate_hz * clamped_release_sec
   let attacksamplesinv : Float = 1.0 / attacksamples
-  let satreleasesamplesinv : Float = 1.0 / (compressor_sample_rate_hz * 0.0025)
+  let satreleasesamplesinv : Float = 1.0 / (sample_rate_hz * 0.0025)
   let dry : Float = 1.0 - clamped_wet
-  let meterrelease : Float = 1.0 - @math.expf(-1.0 / (compressor_sample_rate_hz * 0.325))
+  let meterrelease : Float = 1.0 - @math.expf(-1.0 / (sample_rate_hz * 0.325))
 
   let mut k : Float = 5.0
   let mut kneedboffset : Float = 0.0

--- a/packages/dsp-core/src/effects/delay.mbt
+++ b/packages/dsp-core/src/effects/delay.mbt
@@ -1,4 +1,3 @@
-let delay_sample_rate_hz : Float = 48000.0
 let delay_ref_sample_rate_hz : Float = 44100.0
 let delay_pi : Float = 3.141592653589793238
 let delay_two_pi : Float = delay_pi * 2.0
@@ -48,7 +47,7 @@ fn delay_tan(x : Float) -> Float {
 }
 
 fn delay_cycle_end() -> Int {
-  let mut cycle_end = (delay_sample_rate_hz / delay_ref_sample_rate_hz).to_int()
+  let mut cycle_end = (@utils.get_sample_rate() / delay_ref_sample_rate_hz).to_int()
   if cycle_end < 1 {
     cycle_end = 1
   } else if cycle_end > 4 {

--- a/packages/dsp-core/src/effects/filter.mbt
+++ b/packages/dsp-core/src/effects/filter.mbt
@@ -1,12 +1,16 @@
-let filter_sample_rate_hz : Float = 48000.0
 let filter_pi : Float = 3.141592653589793
 
 pub fn svf_default_sample_rate_hz() -> Float {
-  filter_sample_rate_hz
+  @utils.get_sample_rate()
 }
 
 pub fn svf_compute_g_from_hz(freq_hz : Float, sample_rate_hz : Float) -> Float {
-  let sr = if sample_rate_hz <= 1000.0 { filter_sample_rate_hz } else { sample_rate_hz }
+  let sr =
+    if sample_rate_hz <= 1000.0 {
+      @utils.get_sample_rate()
+    } else {
+      sample_rate_hz
+    }
   let hz = effect_clamp(freq_hz, 5.0, sr * 0.49)
   @math.tanf(filter_pi * (hz / sr))
 }
@@ -70,7 +74,7 @@ fn svf_process_single_channel(
   mode_index : Int,
 ) -> (Float, Float, Float) {
   let cutoff_hz = filter_cutoff_to_hz(cutoff)
-  let g : Float = svf_compute_g_from_hz(cutoff_hz, filter_sample_rate_hz)
+  let g : Float = svf_compute_g_from_hz(cutoff_hz, @utils.get_sample_rate())
   let k : Float = effect_clamp(resonance, 0.0, 1.0) * 2.0
   let (a1, a2, a3) = svf_compute_a(g, k)
   let (v1, v2, next_ic1, next_ic2) = svf_step(input, ic1eq, ic2eq, a1, a2, a3)

--- a/packages/dsp-core/src/effects/filter_test.mbt
+++ b/packages/dsp-core/src/effects/filter_test.mbt
@@ -33,3 +33,9 @@ test "svf mix at zero is dry and at one is filtered" {
   assert_eq(approx_eq_filter(dry_l, 0.4, 0.000001), true)
   assert_eq(approx_eq_filter(wet_l, 0.4, 0.000001), false)
 }
+
+test "svf default sample rate follows runtime configuration" {
+  @utils.set_sample_rate(44100.0)
+  assert_eq(approx_eq_filter(svf_default_sample_rate_hz(), 44100.0, 0.000001), true)
+  @utils.set_sample_rate(48000.0)
+}

--- a/packages/dsp-core/src/effects/reverb_dattorro.mbt
+++ b/packages/dsp-core/src/effects/reverb_dattorro.mbt
@@ -1,6 +1,5 @@
 /// Dattorro-style stereo reverb network.
 /// Memory below heap start is reserved for fixed-size delay lines.
-let reverb_sample_rate_hz : Float = 48000.0
 let reverb_pre_delay_len : Int = 2400
 let reverb_in_ap1_len : Int = 142
 let reverb_in_ap2_len : Int = 107
@@ -222,7 +221,7 @@ fn reverb_allpass_process(base_ptr : Int, idx : Int, input : Float, g : Float) -
 }
 
 pub fn reverb_predelay_ms_to_samples(ms : Float) -> Int {
-  let raw = (reverb_clamp(ms, 0.0, 50.0) * (reverb_sample_rate_hz / 1000.0)).to_int()
+  let raw = (reverb_clamp(ms, 0.0, 50.0) * (@utils.get_sample_rate() / 1000.0)).to_int()
   if raw >= reverb_pre_delay_len { reverb_pre_delay_len - 1 } else { raw }
 }
 

--- a/packages/dsp-core/src/effects/reverb_dattorro_test.mbt
+++ b/packages/dsp-core/src/effects/reverb_dattorro_test.mbt
@@ -4,8 +4,15 @@ fn approx_eq_reverb(a : Float, b : Float, tol : Float) -> Bool {
 }
 
 test "reverb predelay conversion clamps to valid range" {
+  @utils.set_sample_rate(48000.0)
   assert_eq(reverb_predelay_ms_to_samples(-10.0), 0)
   assert_eq(reverb_predelay_ms_to_samples(50.0), 2399)
+}
+
+test "reverb predelay conversion follows configured sample rate" {
+  @utils.set_sample_rate(44100.0)
+  assert_eq(reverb_predelay_ms_to_samples(50.0), 2205)
+  @utils.set_sample_rate(48000.0)
 }
 
 test "reverb dry-wet mix helper returns endpoints" {

--- a/packages/dsp-core/src/exports.mbt
+++ b/packages/dsp-core/src/exports.mbt
@@ -18,6 +18,11 @@ pub fn dsp_init() -> Unit {
   product_reset()
 }
 
+/// Explicit prepare for host to configure runtime-dependent values
+pub fn dsp_prepare(sample_rate : Float) -> Unit {
+  @utils.set_sample_rate(sample_rate)
+}
+
 /// Process audio block — main DSP loop
 pub fn process_block(num_samples : Int) -> Unit {
   process_audio(num_samples)

--- a/packages/dsp-core/src/moon.pkg.json
+++ b/packages/dsp-core/src/moon.pkg.json
@@ -8,6 +8,7 @@
     "wasm": {
       "exports": [
         "dsp_init",
+        "dsp_prepare",
         "process_block",
         "get_param_count",
         "get_param_name",

--- a/packages/dsp-core/src/utils/constants.mbt
+++ b/packages/dsp-core/src/utils/constants.mbt
@@ -1,6 +1,8 @@
 // Memory layout constants
 // Each buffer: max 16384 samples × 4 bytes = 64KB
 
+let sample_rate_hz_box : Array[Float] = [48000.0]
+
 pub let input_left_offset : Int = 0x10000   // 65536
 
 pub let input_right_offset : Int = 0x20000  // 131072
@@ -10,3 +12,17 @@ pub let output_left_offset : Int = 0x30000  // 196608
 pub let output_right_offset : Int = 0x40000 // 262144
 
 pub let string_buf_offset : Int = 0x50000   // 327680 — parameter name string buffer
+
+pub fn set_sample_rate(sample_rate_hz : Float) -> Unit {
+  let safe_sample_rate_hz : Float =
+    if sample_rate_hz < 1000.0 {
+      48000.0
+    } else {
+      sample_rate_hz
+    }
+  sample_rate_hz_box[0] = safe_sample_rate_hz
+}
+
+pub fn get_sample_rate() -> Float {
+  sample_rate_hz_box[0]
+}

--- a/packages/ui-core/public/worklet/processor.js
+++ b/packages/ui-core/public/worklet/processor.js
@@ -32,6 +32,9 @@ class MoonVSTProcessor extends AudioWorkletProcessor {
         this.wasmInstance = instance
         this.wasmMemory = instance.exports.memory
         instance.exports.dsp_init()
+        if (typeof instance.exports.dsp_prepare === 'function') {
+          instance.exports.dsp_prepare(sampleRate)
+        }
         this.ready = true
         this.port.postMessage({ type: 'ready' })
       } catch (err) {

--- a/plugin/include/moonvst/WasmDSP.h
+++ b/plugin/include/moonvst/WasmDSP.h
@@ -33,6 +33,7 @@ private:
 
     // Generic function pointers (looked up by name)
     wasm_function_inst_t fn_init_ = nullptr;
+    wasm_function_inst_t fn_dsp_prepare_ = nullptr;
     wasm_function_inst_t fn_process_block_ = nullptr;
     wasm_function_inst_t fn_get_param_count_ = nullptr;
     wasm_function_inst_t fn_get_param_name_ = nullptr;

--- a/plugin/src/WasmDSP.cpp
+++ b/plugin/src/WasmDSP.cpp
@@ -226,6 +226,7 @@ bool WasmDSP::lookupFunctions()
     fn_init_               = wasm_runtime_lookup_function (moduleInst_, "init");
     if (fn_init_ == nullptr)
         fn_init_ = wasm_runtime_lookup_function (moduleInst_, "dsp_init");
+    fn_dsp_prepare_        = wasm_runtime_lookup_function (moduleInst_, "dsp_prepare");
     fn_process_block_      = wasm_runtime_lookup_function (moduleInst_, "process_block");
     fn_get_param_count_    = wasm_runtime_lookup_function (moduleInst_, "get_param_count");
     fn_get_param_name_     = wasm_runtime_lookup_function (moduleInst_, "get_param_name");
@@ -240,9 +241,19 @@ bool WasmDSP::lookupFunctions()
     return fn_process_block_ != nullptr && fn_get_param_count_ != nullptr;
 }
 
-void WasmDSP::prepare (double /*sampleRate*/, int /*samplesPerBlock*/)
+void WasmDSP::prepare (double sampleRate, int /*samplesPerBlock*/)
 {
-    // Reserved for future use (e.g., passing sample rate to WASM)
+    if (! initialized_.load() || fn_dsp_prepare_ == nullptr)
+        return;
+
+    const ScopedThreadEnv threadEnv;
+    if (! threadEnv.isValid())
+        return;
+
+    wasm_val_t args[1];
+    args[0].kind = WASM_F32;
+    args[0].of.f32 = (float) sampleRate;
+    callVoid (execEnv_, fn_dsp_prepare_, args, 1);
 }
 
 void WasmDSP::processBlock (juce::AudioBuffer<float>& buffer)

--- a/tests/cpp/wasm_dsp_test.cpp
+++ b/tests/cpp/wasm_dsp_test.cpp
@@ -103,6 +103,7 @@ int main()
     auto fn_init = wasm_runtime_lookup_function(inst, "init");
     if (!fn_init)
         fn_init = wasm_runtime_lookup_function(inst, "dsp_init");
+    auto fn_dsp_prepare = wasm_runtime_lookup_function(inst, "dsp_prepare");
     auto fn_get_param_count = wasm_runtime_lookup_function(inst, "get_param_count");
     auto fn_set_param = wasm_runtime_lookup_function(inst, "set_param");
     auto fn_get_param = wasm_runtime_lookup_function(inst, "get_param");
@@ -114,6 +115,7 @@ int main()
         printf("  process_block: %s\n", fn_process_block ? "ok" : "missing");
         printf("  get_param_count: %s\n", fn_get_param_count ? "ok" : "missing");
         printf("  init|dsp_init: %s\n", fn_init ? "ok" : "missing (optional)");
+        printf("  dsp_prepare: %s\n", fn_dsp_prepare ? "ok" : "missing (optional)");
         printf("  set_param/get_param: %s/%s (optional)\n",
                fn_set_param ? "ok" : "missing",
                fn_get_param ? "ok" : "missing");
@@ -146,6 +148,30 @@ int main()
     else
     {
         printf("PASS: init()/dsp_init() not exported (optional)\n");
+    }
+
+    // 6.1 Call dsp_prepare(sampleRate)
+    if (fn_dsp_prepare != nullptr)
+    {
+        float sampleRate = 44100.0f;
+        uint32_t prepareArgs[1] = { 0 };
+        std::memcpy(&prepareArgs[0], &sampleRate, sizeof(float));
+        if (!wasm_runtime_call_wasm(execEnv, fn_dsp_prepare, 1, prepareArgs))
+        {
+            const char* ex = wasm_runtime_get_exception(inst);
+            printf("FAIL: dsp_prepare() call failed%s%s\n", ex ? ": " : "", ex ? ex : "");
+            wasm_runtime_destroy_exec_env(execEnv);
+            wasm_runtime_deinstantiate(inst);
+            wasm_runtime_unload(module);
+            free(aotBuf);
+            wasm_runtime_destroy();
+            return 1;
+        }
+        printf("PASS: dsp_prepare() called\n");
+    }
+    else
+    {
+        printf("PASS: dsp_prepare() not exported (optional)\n");
     }
 
     // 7. Test get_param_count


### PR DESCRIPTION
## Summary
- add runtime sample-rate state in DSP utils and expose dsp_prepare(sample_rate)
- replace hardcoded 48000Hz references in filter/chorus/compressor/delay/reverb with runtime sample rate
- call dsp_prepare from JUCE WasmDSP::prepare() and AudioWorklet processor init path
- extend DSP/C++ tests to cover sample-rate configuration wiring

## Validation
- npm run test:dsp
- npm run build:dsp
- npm run build:dsp:showcase
- npm run test:dsp:showcase
- npm run configure:plugin
- npm run build:plugin
- ctest --test-dir build -C Release --output-on-failure

Closes #25