### PR TITLE
chore: reduce CI time for PRs while keeping full main validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   discover-products:
@@ -12,6 +22,7 @@ jobs:
     outputs:
       products: ${{ steps.discover.outputs.products }}
       default_product: ${{ steps.discover.outputs.default_product }}
+      selected_products: ${{ steps.discover.outputs.selected_products }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,9 +31,16 @@ jobs:
         run: |
           products_json="$(node -e "const fs=require('fs');const dirs=fs.readdirSync('products',{withFileTypes:true}).filter((d)=>d.isDirectory()).map((d)=>d.name).sort();if(dirs.length===0){throw new Error('no products found under products/');}process.stdout.write(JSON.stringify(dirs));")"
           default_product="$(node -e "const fs=require('fs');const dirs=fs.readdirSync('products',{withFileTypes:true}).filter((d)=>d.isDirectory()).map((d)=>d.name).sort();if(dirs.includes('template')){process.stdout.write('template');}else{process.stdout.write(dirs[0]);}")"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            selected_products="$(node -e "process.stdout.write(JSON.stringify([process.argv[1]]));" "$default_product")"
+          else
+            selected_products="$products_json"
+          fi
           echo "products=$products_json" >> "$GITHUB_OUTPUT"
           echo "default_product=$default_product" >> "$GITHUB_OUTPUT"
+          echo "selected_products=$selected_products" >> "$GITHUB_OUTPUT"
           echo "Discovered products: $products_json"
+          echo "Selected products for this run: $selected_products"
 
   build-macos:
     runs-on: macos-26
@@ -41,6 +59,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            packages/ui-core/package-lock.json
+
+      - name: Cache MoonBit
+        uses: actions/cache@v4
+        with:
+          path: ~/.moon
+          key: ${{ runner.os }}-moonbit-${{ hashFiles('scripts/setup-macos.sh') }}
 
       - name: Log macOS toolchain info
         shell: bash
@@ -70,11 +98,11 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
           security default-keychain -d user -s "$KEYCHAIN_PATH"
 
-      - name: Build all products
+      - name: Build selected products
         shell: bash
         run: |
           set -euo pipefail
-          products='${{ needs.discover-products.outputs.products }}'
+          products='${{ needs.discover-products.outputs.selected_products }}'
           mkdir -p ci-artifacts
           for product in $(node -e "const p=JSON.parse(process.argv[1]);console.log(p.join(' '));" "$products"); do
             echo "=== Building product: $product ==="
@@ -162,6 +190,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            packages/ui-core/package-lock.json
+
+      - name: Cache MoonBit
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.USERPROFILE }}\.moon
+          key: ${{ runner.os }}-moonbit-${{ hashFiles('scripts/setup-windows.ps1') }}
 
       - name: Cache LLVM deps
         id: cache-llvm
@@ -176,10 +214,10 @@ jobs:
         shell: pwsh
         run: powershell -ExecutionPolicy Bypass -File scripts/setup-windows.ps1
 
-      - name: Build all products
+      - name: Build selected products
         shell: pwsh
         run: |
-          $products = '${{ needs.discover-products.outputs.products }}' | ConvertFrom-Json
+          $products = '${{ needs.discover-products.outputs.selected_products }}' | ConvertFrom-Json
           New-Item -ItemType Directory -Force -Path "ci-artifacts" | Out-Null
           foreach ($product in $products) {
             Write-Host "=== Building product: $product ==="
@@ -224,11 +262,11 @@ jobs:
           name: moonvst-macos-products
           path: products
 
-      - name: Validate and run smoke tests for all products
+      - name: Validate and run smoke tests for selected products
         shell: bash
         run: |
           set -euo pipefail
-          products='${{ needs.discover-products.outputs.products }}'
+          products='${{ needs.discover-products.outputs.selected_products }}'
           for product in $(node -e "const p=JSON.parse(process.argv[1]);console.log(p.join(' '));" "$products"); do
             echo "=== Testing product: $product ==="
             test -d "products/$product/plugin/VST3/${product}.vst3"
@@ -255,10 +293,10 @@ jobs:
           name: moonvst-windows-products
           path: products
 
-      - name: Validate and run smoke tests for all products
+      - name: Validate and run smoke tests for selected products
         shell: pwsh
         run: |
-          $products = '${{ needs.discover-products.outputs.products }}' | ConvertFrom-Json
+          $products = '${{ needs.discover-products.outputs.selected_products }}' | ConvertFrom-Json
           foreach ($product in $products) {
             Write-Host "=== Testing product: $product ==="
             if (-not (Test-Path "products/$product/plugin/VST3/$product.vst3")) { throw "VST3 artifact missing for $product" }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,17 @@ name: Test
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dsp-test-template:
@@ -17,6 +27,12 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: package-lock.json
+
+      - name: Cache MoonBit
+        uses: actions/cache@v4
+        with:
+          path: ~/.moon
+          key: ${{ runner.os }}-moonbit-${{ hashFiles('package-lock.json') }}
 
       - name: Install root dependencies
         run: npm ci
@@ -40,6 +56,12 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: package-lock.json
+
+      - name: Cache MoonBit
+        uses: actions/cache@v4
+        with:
+          path: ~/.moon
+          key: ${{ runner.os }}-moonbit-${{ hashFiles('package-lock.json') }}
 
       - name: Install root dependencies
         run: npm ci
@@ -67,6 +89,12 @@ jobs:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: package-lock.json
+
+      - name: Cache MoonBit
+        uses: actions/cache@v4
+        with:
+          path: ~/.moon
+          key: ${{ runner.os }}-moonbit-${{ hashFiles('package-lock.json') }}
 
       - name: Install root dependencies
         run: npm ci
@@ -143,9 +171,11 @@ jobs:
         run: npm run test:component
 
       - name: Install Playwright browser
+        if: github.event_name != 'pull_request'
         working-directory: packages/ui-core
         run: npx playwright install --with-deps chromium
 
       - name: Run UI E2E tests
+        if: github.event_name != 'pull_request'
         working-directory: packages/ui-core
         run: npm run test:e2e

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -82,12 +82,20 @@ make -j$(sysctl -n hw.ncpu)
 # 6. Install UI dependencies
 echo "=== Installing UI dependencies ==="
 cd "$ROOT_DIR/packages/ui-core"
-npm install
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    npm ci
+else
+    npm install
+fi
 
 # 7. Install root dependencies
 echo "=== Installing root dependencies ==="
 cd "$ROOT_DIR"
-npm install
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    npm ci
+else
+    npm install
+fi
 
 echo ""
 echo "=== Setup complete! ==="

--- a/scripts/setup-windows.ps1
+++ b/scripts/setup-windows.ps1
@@ -167,12 +167,20 @@ if (-not (Test-Path $WebView2Dir)) {
 # 7. Install UI dependencies
 Write-Host "=== Installing UI dependencies ==="
 Set-Location "$RootDir/packages/ui-core"
-npm install
+if ($env:GITHUB_ACTIONS) {
+    npm ci
+} else {
+    npm install
+}
 
 # 8. Install root dependencies
 Write-Host "=== Installing root dependencies ==="
 Set-Location "$RootDir"
-npm install
+if ($env:GITHUB_ACTIONS) {
+    npm ci
+} else {
+    npm install
+}
 
 Write-Host ""
 Write-Host "=== Setup complete! ==="

--- a/tests/ci/workflow-policy.test.mjs
+++ b/tests/ci/workflow-policy.test.mjs
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+
+const buildWorkflow = readFileSync(".github/workflows/build.yml", "utf8");
+const testWorkflow = readFileSync(".github/workflows/test.yml", "utf8");
+const setupWindows = readFileSync("scripts/setup-windows.ps1", "utf8");
+const setupMacos = readFileSync("scripts/setup-macos.sh", "utf8");
+
+assert.match(
+  buildWorkflow,
+  /concurrency:\s*[\s\S]*cancel-in-progress:\s*true/m,
+  "build workflow must cancel stale in-progress runs",
+);
+
+assert.match(
+  buildWorkflow,
+  /selected_products/,
+  "build workflow must compute selected products for PR vs main",
+);
+
+assert.match(
+  buildWorkflow,
+  /needs\.discover-products\.outputs\.selected_products/,
+  "build and artifact tests must use selected_products",
+);
+
+assert.match(
+  buildWorkflow,
+  /paths-ignore:\s*[\s\S]*\*\*\/\*\.md/m,
+  "build workflow should skip docs-only changes",
+);
+
+assert.match(
+  testWorkflow,
+  /paths-ignore:\s*[\s\S]*\*\*\/\*\.md/m,
+  "test workflow should skip docs-only changes",
+);
+
+assert.match(
+  testWorkflow,
+  /Run UI E2E tests[\s\S]*if:\s*github\.event_name\s*!=\s*'pull_request'/m,
+  "UI E2E should be skipped on pull requests",
+);
+
+assert.match(
+  setupWindows,
+  /\$env:GITHUB_ACTIONS[\s\S]*npm ci[\s\S]*else[\s\S]*npm install/m,
+  "windows setup should use npm ci under CI",
+);
+
+assert.match(
+  setupMacos,
+  /GITHUB_ACTIONS[\s\S]*npm ci[\s\S]*else[\s\S]*npm install/m,
+  "macOS setup should use npm ci under CI",
+);
+
+console.log("CI workflow policy checks passed");


### PR DESCRIPTION
## Summary
- add workflow concurrency and cancel-in-progress for Build/Test
- skip heavy Build/Test workflows on docs-only changes
- run Build on PR with default product only (keep multi-OS), full products on main/tags
- skip UI E2E on pull_request and keep it on push to main
- switch setup scripts to use npm ci under CI (keep npm install locally)
- add CI policy regression test for workflow rules

## Validation
- node tests/ci/workflow-policy.test.mjs

Closes #34